### PR TITLE
Fix typo in h-card preview

### DIFF
--- a/templates/validate-h-card.html.php
+++ b/templates/validate-h-card.html.php
@@ -59,7 +59,7 @@
 				<?php if (Mf2\hasProp($hCard, 'url')): ?>
 				<ul>
 					<?php foreach ($hCard['properties']['url'] as $pUrl): ?>
-					<li><a href="<?= $Url ?>"><?= $pUrl ?></a></li>
+					<li><a href="<?= $pUrl ?>"><?= $pUrl ?></a></li>
 					<?php endforeach ?>
 				</ul>
 				<?php else: ?>


### PR DESCRIPTION
The URL of the link was set to a non-existent `$Url` instead of `$pUrl`. This used to reload the page when clicking on any URL.