### PR TITLE
Adds next/home/previous navigation to the footer of individual steps.

### DIFF
--- a/templates/send-webmentions.html.php
+++ b/templates/send-webmentions.html.php
@@ -42,4 +42,10 @@
 			<button type="submit"class="btn btn-large btn-block btn-primary">Send Mentions</button>
 		</div>
 	</form>
+
+	<?php if (empty($composite_view)): ?>
+		<hr />
+		<p> <a href="/validate-h-entry/">Previous Step</a> | <a href="/">Home</a> </p>
+	<?php endif ?>
+
 </div>

--- a/templates/validate-h-card.html.php
+++ b/templates/validate-h-card.html.php
@@ -99,4 +99,10 @@
 	<?php endif ?>
 	
 	<small>Want to be able to use h-card data in your code? Check out the open-source <a href="http://microformats.org/wiki/parsers">implementations</a>.</small>
+
+	<?php if (empty($composite_view)): ?>
+		<hr />
+		<p> <a href="/validate-rel-me/">Previous Step</a> | <a href="/">Home</a> | <a href="/validate-h-entry/">Next Step</a> </p>
+	<?php endif ?>
+
 </div>

--- a/templates/validate-h-entry.html.php
+++ b/templates/validate-h-entry.html.php
@@ -221,4 +221,10 @@
 	<?php endif ?>
 	
 	<small>Want to be able to use h-entry data in your code? Check out the open-source <a href="http://microformats.org/wiki/parsers">implementations</a>.</small>
+
+	<?php if (empty($composite_view)): ?>
+		<hr />
+		<p> <a href="/validate-h-card/">Previous Step</a> | <a href="/">Home</a> | <a href="/send-webmentions/">Next Step</a> </p>
+	<?php endif ?>
+
 </div>

--- a/templates/validate-rel-me.html.php
+++ b/templates/validate-rel-me.html.php
@@ -46,4 +46,10 @@
 	</form>
 	
 	<small>Want to be able to use rel-me data in your code? Check out the open source <a href="http://indiewebcamp.com/rel-me#Implementations">implementations</a>.</small>
+
+	<?php if (empty($composite_view)): ?>
+		<hr />
+		<p> <a href="/">Home</a> | <a href="/validate-h-card/">Next Step</a> </p>
+	<?php endif ?>
+
 </div>

--- a/web/index.php
+++ b/web/index.php
@@ -143,7 +143,7 @@ if (PHP_SAPI === 'cli-server') {
 $app = new Silex\Application();
 
 $app->get('/', function () {
-	return render('index.html');
+	return render('index.html', array('composite_view' => true));
 });
 
 $app->get('/validate-rel-me/', function (Http\Request $request) {


### PR DESCRIPTION
Fixes #11.

The individual step templates are used to create the index page as well, so I added a boolean `composite_view` variable when rendering the index. The templates for the steps check if that variable exists and if it doesn't, adds the navigation links at the bottom.