### PR TITLE
add more precision about where to add h-card links

### DIFF
--- a/templates/validate-h-entry.html.php
+++ b/templates/validate-h-entry.html.php
@@ -22,9 +22,9 @@
 			<h4>Success!</h4>
 
 			<p>We found the following <strong><?= $postType ?></strong> <code>h-entry</code> on your site:</p>
-			
+
 			<div class="preview-h-entry preview-block">
-				
+
 				<?php if ($nameState == 'valid'): ?>
 				<p class="property-block-name">Name</p>
 				<p class="p-name"><?= Mf2\getProp($hEntry, 'name') ?></p>
@@ -36,7 +36,7 @@
 					<p>You should always manually specify what the <code>name</code> of a post is. If it doesn’t have one, make the name the same as the content, e.g. <code>&lt;div class=&quot;e-content p-name&quot;>…</code></p>
 				</div>
 				<?php endif ?>
-				
+
 				<p class="property-block-name">Author</p>
 				<?php if (Mf2\hasProp($hEntry, 'author')): $author = $hEntry['properties']['author'][0]; ?>
 				<?php if (Mf2\isMicroformat($author)): ?>
@@ -65,8 +65,8 @@
 					<pre><code>&lt;a rel=&quot;author&quot; class=&quot;p-author h-card&quot; href=&quot;…&quot;>Your Name&lt;/a></code></pre>
 				</div>
 				<?php endif ?>
-				
-				
+
+
 				<?php if ($postType == 'reply'): ?>
 					<p class="property-block-name">In Reply To</p>
 					<ul>
@@ -78,7 +78,7 @@
 								<?php if (!in_array('h-cite', $irt['type'])): ?>
 								<p>The nested <code>in-reply-to</code> microformat should be an <a href="http://microformats.org/wiki/h-cite"><code>h-cite</code></a> as it refers to off-site content.</p>
 								<?php endif ?>
-								
+
 								<?php if (Mf2\hasProp($irt, 'url')): ?>
 									<a href="<?= Mf2\getProp($irt, 'url') ?>"><?= Mf2\getProp($irt, 'url') ?></a>
 								<?php else: ?>
@@ -90,7 +90,7 @@
 						</li>
 						<?php endforeach ?>
 					</ul>
-					
+
 				<?php elseif ($postType == 'like'): ?>
 					<p class="property-block-name">Like Of</p>
 					<?php if (is_string($hEntry['properties']['like-of'][0])): ?>
@@ -99,7 +99,7 @@
 						<?php if (!in_array('h-cite', Mf2\getProp($hEntry, 'like-of'))): ?>
 						<p>The nested <code>h-cite</code> microformat should be an <a href="http://microformats.org/wiki/h-cite"><code>h-cite</code></a> as it refers to off-site content.</p>
 						<?php endif ?>
-						
+
 						<?php if (Mf2\hasProp(Mf2\getProp($hEntry, 'like-of'), 'url')): ?>
 							<a href="<?= Mf2\getProp(Mf2\getProp($hEntry, 'like-of'), 'url') ?>"><?= Mf2\getProp(Mf2\getProp($hEntry, 'like-of'), 'url') ?></a>
 						<?php else: ?>
@@ -108,7 +108,7 @@
 					<?php else: ?>
 						The value for a <code>like-of</code> property should be a URL or an embedded <a href="http://microformats.org/wiki/h-cite"><code>h-cite</code></a>.
 					<?php endif ?>
-					
+
 				<?php elseif ($postType == 'repost'): ?>
 					<p class="property-block-name">Repost Of</p>
 					<?php if (is_string(Mf2\getProp($hEntry, 'repost-of'))): ?>
@@ -117,7 +117,7 @@
 						<?php if (!in_array('h-cite', Mf2\getProp($hEntry, 'repost-of'))): ?>
 						<p>The nested <code>h-cite</code> microformat should be an <a href="http://microformats.org/wiki/h-cite"><code>h-cite</code></a> as it refers to off-site content.</p>
 						<?php endif ?>
-						
+
 						<?php if (Mf2\hasProp(Mf2\getProp($hEntry, 'repost-of'), 'url')): ?>
 							<a href="<?= Mf2\getProp(Mf2\getProp($hEntry, 'repost-of'), 'url') ?>"><?= Mf2\getProp(Mf2\getProp($hEntry, 'repost-of'), 'url') ?></a>
 						<?php else: ?>
@@ -127,8 +127,8 @@
 						The value for a <code>repost-of</code> property should be a URL or an embedded <a href="http://microformats.org/wiki/h-cite"><code>h-cite</code></a>.
 					<?php endif ?>
 				<?php endif ?>
-				
-				
+
+
 				<p class="property-block-name">Content</p>
 				<?php if (Mf2\hasProp($hEntry, 'content')): ?>
 				<div class="e-content"><?= Mf2\getProp($hEntry, 'content') ?></div>
@@ -140,7 +140,7 @@
 					<p>Add some content! <code class="pull-right">&lt;p class=&quot;e-content&quot;>…</code></p>
 				</div>
 				<?php endif ?>
-				
+
 				<p class="property-block-name">Published
 				<?php if (Mf2\hasProp($hEntry, 'published')): ?>
 				<time class="dt-published"><?= Mf2\getProp($hEntry, 'published') ?></time></p>
@@ -154,14 +154,14 @@
 					<p><code>&lt;time class=&quot;dt-published&quot; datetime=&quot;YYYY-MM-DD HH:MM:SS&quot;>The Date&lt;/time></code></p>
 				</div>
 				<?php endif ?>
-				
+
 				<p class="property-block-name">URL
 				<?php if (Mf2\hasProp($hEntry, 'url')): ?>
 				<a href="<?= Mf2\getProp($hEntry, 'url') ?>"><?= Mf2\getProp($hEntry, 'url') ?></a></p>
 				<?php else: ?>
 				</p><p class="empty-property-block">Add a URL! <code class="pull-right">&lt;a class=&quot;u-url&quot; href=&quot;…&quot;>…&lt;/a></code></p>
 				<?php endif ?>
-				
+
 				<p class="property-block-name">Syndicated Copies</p>
 				<?php if (Mf2\hasProp($hEntry, 'syndication')): ?>
 				<ul>
@@ -175,7 +175,7 @@
 					<p><code>&lt;a rel=&quot;syndication&quot; class=&quot;u-syndication&quot; href=&quot;…&quot;>…&lt;/a></code></p>
 				</div>
 				<?php endif ?>
-				
+
 				<p class="property-block-name">Categories</p>
 				<?php if (Mf2\hasProp($hEntry, 'category')): ?>
 				<ul>
@@ -215,11 +215,11 @@
 
 	<p>It’s a common convention for the published datetime to be a link to the post itself, but they can be separate if you want.</p>
 
-	<p>There should also be some way to discover the author of the post — either link to your homepage (which should have your h-card on)from anywhere on the page with <code>rel=author</code>, or optionally embed a <code>p-author h-card</code> in the h-entry.</p>
+	<p>There should also be some way to discover the author of the post — either link to your homepage (which should have your h-card on it) from anywhere within the body of the page with <code>rel=author</code>, or optionally embed a <code>p-author h-card</code> in the h-entry.</p>
 
 	<p>The web is an expressive medium, and as such there are many other properties which you can add to your posts. Check out the <a href="https://microformats.org/wiki/h-entry">h-entry documentation</a> for a full list.</p>
 	<?php endif ?>
-	
+
 	<small>Want to be able to use h-entry data in your code? Check out the open-source <a href="http://microformats.org/wiki/parsers">implementations</a>.</small>
 
 	<?php if (empty($composite_view)): ?>


### PR DESCRIPTION
Since the validator isn't parsing `<link>` elements within the `<head>` of the page at this time, be more precise when telling people where to add their `h-card` links.  Specifically instruct people to insert such links within the `<body>` of the page.

I also trimmed out some trailing whitespace.  I did not remove newlines, but simply removed whitespace.

Closes #61 