### PR TITLE
Display logo & suppress photo notice on logo

### DIFF
--- a/templates/validate-h-card.html.php
+++ b/templates/validate-h-card.html.php
@@ -93,6 +93,8 @@
 			<div class="preview-h-card preview-block">
 				<?php if (Mf2\hasProp($hCard, 'photo')): ?>
 				<img class="photo-block" src="<?= Mf2\getProp($hCard, 'photo')?>" alt="" />
+				<?php if (Mf2\hasProp($hCard, 'logo')): ?>
+				<img class="logo-block" src="<?= Mf2\getProp($hCard, 'logo')?>" alt="" />
 				<?php else: ?>
 				<div class="empty-property-block photo-block">
 					<p>Add a photo!</p>


### PR DESCRIPTION
Had a chat about this last night on Indieweb chat. Just finished updating my site as a test-candidate.

As a user who is deliberately opting not to display a photograph of myself, who would rather be represented by a graphic than a photograph, in the absence of avatar support. I would like to see my logo displayed via indiewebify.me, and have the helpful message to include a photo suppressed, if I supply a logo, but not a photo; so that I'm not bothered by the message and do not feel friction with the choice to represent myself in this way.