### PR TITLE
If inside if causing issues, should be elseif

### DIFF
--- a/templates/validate-h-card.html.php
+++ b/templates/validate-h-card.html.php
@@ -93,7 +93,7 @@
 			<div class="preview-h-card preview-block">
 				<?php if (Mf2\hasProp($hCard, 'photo')): ?>
 				<img class="photo-block" src="<?= Mf2\getProp($hCard, 'photo')?>" alt="" />
-				<?php if (Mf2\hasProp($hCard, 'logo')): ?>
+				<?php elseif (Mf2\hasProp($hCard, 'logo')): ?>
 				<img class="logo-block" src="<?= Mf2\getProp($hCard, 'logo')?>" alt="" />
 				<?php else: ?>
 				<div class="empty-property-block photo-block">


### PR DESCRIPTION
Quick fix to get the site rendering again.

From reading #86 it seems like logo is meant as a fallback to photo there, to get it to display only as a fallback `elseif` is used.

Works for me locally.