### PR TITLE
Update validate-h-card

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/barnabywalters/php-mf-cleaner.git",
-                "reference": "e70b7b9a74b734527aa7e62d36fdbf3607559ad5"
+                "reference": "71566ebb40023d652f374eb80f9bd9c4c7d34cd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/barnabywalters/php-mf-cleaner/zipball/e70b7b9a74b734527aa7e62d36fdbf3607559ad5",
-                "reference": "e70b7b9a74b734527aa7e62d36fdbf3607559ad5",
+                "url": "https://api.github.com/repos/barnabywalters/php-mf-cleaner/zipball/71566ebb40023d652f374eb80f9bd9c4c7d34cd6",
+                "reference": "71566ebb40023d652f374eb80f9bd9c4c7d34cd6",
                 "shasum": ""
             },
             "require-dev": {
@@ -27,6 +27,7 @@
             "suggest": {
                 "mf2/mf2": "To parse microformats2 structures from (X)HTML"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -44,7 +45,11 @@
                 }
             ],
             "description": "Cleans up microformats2 array structures",
-            "time": "2018-11-14T20:44:19+00:00"
+            "support": {
+                "issues": "https://github.com/barnabywalters/php-mf-cleaner/issues",
+                "source": "https://github.com/barnabywalters/php-mf-cleaner/tree/master"
+            },
+            "time": "2022-06-28T17:28:22+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",
@@ -2021,5 +2026,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }

--- a/templates/validate-h-card.html.php
+++ b/templates/validate-h-card.html.php
@@ -1,4 +1,5 @@
 <?php
+
 	use BarnabyWalters\Mf2;
 
 	$optional_properties = [
@@ -38,58 +39,70 @@
 		'anniversary' => 'Anniversary',
 	];
 
+	# default h-card to show properties for
+	$hCard = null;
 ?>
+
 <div class="row demo-row">
 	<div class="span12">
 
-	<h1><span class="fui-new"></span> Publishing on the IndieWeb <small>Level 2</small></h1>
+		<h1><span class="fui-new"></span> Publishing on the IndieWeb <small>Level 2</small></h1>
 
-	<h2>1. Mark up your content (Profile, Notes, Articles, etc…) with <a href="http://microformats.org/" target="_blank">microformats2</a></h2>
+		<h2>1. Mark up your content (Profile, Notes, Articles, etc…) with <a href="https://microformats.org/" target="_blank">microformats2</a></h2>
 
-	<p>Other humans can already understand your profile information and the things you post on your site. By adding a few simple class names to your HTML, other people’s software can understand it and use it for things like <a href="https://indieweb.org/reply-context">reply contexts</a>, <a href="https://indieweb.org/comment">cross-site comments</a>, <a href="https://indieweb.org/rsvp">event RSVPs</a>, and more.</p>
+		<p>Other humans can already understand your profile information and the things you post on your site. By adding a few simple class names to your HTML, other people’s software can understand it and use it for things like <a href="https://indieweb.org/reply-context">reply contexts</a>, <a href="https://indieweb.org/comment">cross-site comments</a>, <a href="https://indieweb.org/rsvp">event RSVPs</a>, and more.</p>
 
-	<h3>Check your <b>homepage <a href="http://microformats.org/wiki/h-card" target="_blank">h-card</a></b>:</h3>
+		<h3>Check your <b>homepage <a href="https://microformats.org/wiki/h-card" target="_blank">h-card</a></b>:</h3>
 
-	<form class="row" action="/validate-h-card/" method="get">
-		<div class="span4">
-			<input type="text" id="validate-h-card-url" name="url" value="<?= $url ?>" placeholder="http://yoursite.com" class="span4" />
+		<label for="validate-h-card-url">Enter your URL:</label>
+		<form class="row" action="/validate-h-card/" method="get">
+			<div class="span4">
+				<input type="text" id="validate-h-card-url" name="url" value="<?= $url ?? '' ?>" placeholder="https://example.com/" class="span4" required />
+			</div>
+			<div class="span3">
+				<button type="submit" id="validate-h-card" class="btn btn-large btn-block btn-primary">Validate h-card</button>
+			</div>
+		</form>
+
+	<?php if (isset($error)): ?>
+		<div class="result alert alert-warning">
+			<h3> Something Went Wrong! </h3>
+			<p> When fetching <code><?= $url ?></code>, we got this problem: </p>
+			<p> <?= $error['message'] ?> </p>
 		</div>
-		<div class="span3">
-			<button type="submit" id="validate-h-card" class="btn btn-large btn-block btn-primary">Validate h-card</button>
-		</div>
-	</form>
+	<?php endif; ?>
 
-	<?php if ($error or $showResult): ?>
-	<div class="result alert <?php if ($error): ?>alert-warning<?php else: ?>alert-success<?php endif ?>">
-		<?php if ($error): ?>
-			<h3>Something Went Wrong!</h3>
-			<p>When fetching <code><?= $url ?></code>, we got this problem:</p>
-			<p><?= $error['message'] ?></p>
+	<?php if ($showResult): ?>
+		<div class="result alert alert-success">
+
+		<?php if ($representativeHCard): $hCard = $representativeHCard; ?>
+
+			<h3> Success! </h3>
+			<p> This representative h-card was found on your site: </p>
+
+		<?php elseif (count($allHCards) > 0): $hCard = $allHCards[0]; ?>
+
+			<h3> Almost there! </h3>
+			<p> Multiple h-cards were found on your site! Consider only having one and marking it up as the <a href="https://microformats.org/wiki/representative-h-card-authoring">representative h-card</a>. </p>
+			<p> To identify the h-card that <em>represents</em> the page, you can: </p>
+			<ul>
+				<li> Add <code>class=&quot;u-url u-uid&quot;</code> on the h-card’s link to <?=htmlspecialchars($url);?> </li>
+				<li> <b>Or:</b> add <code>class=&quot;u-url&quot; rel=&quot;me&quot;</code> on the h-card’s link to <?=htmlspecialchars($url);?> </li>
+			</ul>
+			<p> Here is the first h-card found: </p>
+
 		<?php else: ?>
-			<?php if (count($representativeHCards) == 1): $hCard = $representativeHCards[0]; ?>
-				<h3>Success!</h3>
-				<p>This representative <code>h-card</code> was found on your site:</p>
-			<?php elseif (count($representativeHCards) > 1): $hCard = $representativeHCards[0] ?>
-				<h3>Almost there!</h3>
-				<p>Multiple representative h-cards were found on your site! Consider only having one. Here’s the first one:</p>
-			<?php elseif (count($representativeHCards) == 0 and $firstHCard !== null): $hCard = $firstHCard; ?>
-				<h3>Almost there!</h3>
-				<p>An h-card was found on your site, but it’s not marked up as the <a href="http://microformats.org/wiki/representative-h-card-parsing">representative h-card</a>!</p>
-				<p> To identify the h-card that <em>represents</em> the page, you can: </p>
-				<ul>
-					<li> Add <code>class=&quot;u-url u-uid&quot;</code> on the h-card's link to <?=htmlspecialchars($url);?> </li>
-					<li> <b>Or:</b> add <code>class=&quot;u-url&quot; rel=&quot;me&quot;</code> on the h-card's link to <?=htmlspecialchars($url);?> </li>
-				</ul>
-			<?php else: $hCard = null; ?>
-				<h3>No h-cards found</h3>
-				<p>No h-cards were found on your site! Adding one can be as simple as this:</p>
 
-				<pre><code>&lt;a class=&quot;h-card&quot; rel=&quot;me&quot; href=&quot;<?= $url ?>&quot;>Your Name&lt;/a></code></pre>
+			<h3> No h-cards found </h3>
+			<p> No h-cards were found on your site! Adding one can be as simple as this: </p>
 
-				<p>But you can also add other properties for a more detailed profile — see <a href="http://microformats.org/wiki/h-card">h-card on the microformats wiki</a> for a full list.</p>
-			<?php endif ?>
+			<pre><code>&lt;a href=&quot;<?= $url ?>&quot; class=&quot;h-card&quot; rel=&quot;me&quot;>Your Name&lt;/a&gt;</code></pre>
 
-			<?php if ($hCard): ?>
+			<p> You can also add other properties for a more detailed profile — see <a href="https://microformats.org/wiki/h-card">h-card on the microformats wiki</a> for a full list. </p>
+
+		<?php endif; ?>
+
+		<?php if ($hCard): ?>
 			<div class="preview-h-card preview-block">
 				<?php if (Mf2\hasProp($hCard, 'photo')): ?>
 				<img class="photo-block" src="<?= Mf2\getProp($hCard, 'photo')?>" alt="" />
@@ -104,22 +117,22 @@
 				<p class="p-name"><?= Mf2\getProp($hCard, 'name') ?></p>
 
 				<p class="property-block-name">URL</p>
-				<?php if (Mf2\hasProp($hCard, 'url')): ?>
+				<?php if (Mf2\hasProp($hCard, 'url')): $urls = Mf2\getPlaintextArray($hCard, 'url'); ?>
 				<ul>
-					<?php foreach ($hCard['properties']['url'] as $pUrl): ?>
+					<?php foreach ($urls as $pUrl): ?>
 					<li><a href="<?= $pUrl ?>"><?= $pUrl ?></a></li>
 					<?php endforeach ?>
 				</ul>
 				<?php else: ?>
 				<div class="empty-property-block">
-					<p>Add your URLs! <code class="pull-right">&lt;a rel=&quot;me&quot; class=&quot;u-url&quot;>…&lt;/a></code></p>
+					<p>Add your URLs! <code class="pull-right">&lt;a rel=&quot;me&quot; class=&quot;u-url&quot;>…&lt;/a&gt;</code></p>
 				</div>
 				<?php endif ?>
 
-				<?php if (Mf2\hasProp($hCard, 'email')): ?>
+				<?php if (Mf2\hasProp($hCard, 'email')): $emails = Mf2\getPlaintextArray($hCard, 'email'); ?>
 				<p class="property-block-name">Email</p>
 				<ul>
-					<?php foreach ($hCard['properties']['email'] as $email): ?>
+					<?php foreach ($emails as $email): ?>
 					<li><a href="<?= $email ?>"><?= $email ?></a></li>
 					<?php endforeach ?>
 				</ul>
@@ -130,7 +143,7 @@
 				<p><?= Mf2\getProp($hCard, 'note') ?></p>
 				<?php else: ?>
 				<div class="empty-property-block">
-					<p>Got a brief bio like a Twitter/Instagram bio? Add it to your own h-card as a note property! <code class="pull-right">&lt;p class=&quot;p-note&quot;>…&lt/p></code></p>
+					<p>Got a brief bio like a Twitter/Instagram bio? Add it to your own h-card as a note property! <code class="pull-right">&lt;p class=&quot;p-note&quot;>…&lt/p&gt;</code></p>
 				</div>
 				<?php endif ?>
 
@@ -146,17 +159,16 @@
 				}
 				?>
 
-				<p> <a href="http://microformats.org/wiki/h-card#Properties">See the full list of h-card properties</a>. </p>
-
+				<p> <a href="https://microformats.org/wiki/h-card#Properties">See the full list of h-card properties</a>. </p>
 			</div>
-			<?php endif ?>
-
-			<?= $render('silo-hint.html', array('url' => $url)) ?>
 		<?php endif ?>
-	</div>
-	<?php endif ?>
 
-	<small>Want to be able to use h-card data in your code? Check out the open-source <a href="http://microformats.org/wiki/parsers">implementations</a>.</small>
+		<?= $render('silo-hint.html', array('url' => $url)) ?>
+
+		</div>
+	<?php endif; ?>
+
+	<small>Want to be able to use h-card data in your code? Check out the open-source <a href="https://microformats.org/wiki/parsers">implementations</a>.</small>
 
 	<?php if (empty($composite_view)): ?>
 		<hr />
@@ -165,3 +177,4 @@
 
 	</div><!--/.span-->
 </div>
+

--- a/templates/validate-h-card.html.php
+++ b/templates/validate-h-card.html.php
@@ -80,10 +80,16 @@
 			<h3> Success! </h3>
 			<p> This representative h-card was found on your site: </p>
 
-		<?php elseif (count($allHCards) > 0): $hCard = $allHCards[0]; ?>
+		<?php elseif (count($allHCards) > 0):
+			$hCard = $allHCards[0];
+			$intro_phrase = 'An h-card was found on your site! Consider ';
+			if (count($allHCards) > 1) {
+				$intro_phrase = 'Multiple h-cards were found on your site! Consider only having one and  ';
+			}
+		?>
 
 			<h3> Almost there! </h3>
-			<p> Multiple h-cards were found on your site! Consider only having one and marking it up as the <a href="https://microformats.org/wiki/representative-h-card-authoring">representative h-card</a>. </p>
+			<p> <?=$intro_phrase?> marking it up as the <a href="https://microformats.org/wiki/representative-h-card-authoring">representative h-card</a>. </p>
 			<p> To identify the h-card that <em>represents</em> the page, you can: </p>
 			<ul>
 				<li> Add <code>class=&quot;u-url u-uid&quot;</code> on the h-card’s link to <?=htmlspecialchars($url);?> </li>

--- a/web/index.php
+++ b/web/index.php
@@ -313,116 +313,17 @@ $app->get('/validate-h-card/', function (Http\Request $request) use($app) {
 		$allHCards = Mf2\findMicroformatsByType($mfs, 'h-card');
 		$representativeHCard = Mf2\getRepresentativeHCard($mfs, $url);
 
-		/*header('Content-Type: text/plain; charset=utf8');
-		var_dump($representativeHCard);
-		echo PHP_EOL . count($allHCards);
-		exit;*/
-
-		$firstHCard = null;
-		if (count($allHCards) > 0) {
-			$firstHCard = $allHCards[0];
-		}
-
 		return crossOriginResponse(
 			render(
 				'validate-h-card.html',
 				[
 					'showResult' => true,
-					'firstHCard' => $firstHCard,
 					'allHCards' => $allHCards,
-					'representativeHCards' => [],
 					'representativeHCard' => $representativeHCard,
 					'url' => htmlspecialchars($url)
 				]
 			)
 		);
-
-
-
-
-
-
-
-		print_r(Mf2\getRepresentativeHCard($mfs, $url)); exit;
-
-		$representativeHCards = array();
-		$allhCards = $hCards = Mf2\findMicroformatsByType($mfs, 'h-card');
-
-		$relMeUrls = empty($mfs['rels']['me']) ? array() : $mfs['rels']['me'];
-
-		# check for `url` and `uid` properties matching the page URL
-		foreach ($hCards as $index => $hCard) {
-			if (Mf2\hasProp($hCard, 'uid') && Mf2\hasProp($hCard, 'url')
-				&& Mf2\urlsMatch(Mf2\getPlaintext($hCard, 'uid'), $url)
-				&& count(array_filter($hCard['properties']['url'], function ($u) use ($url) {
-					return Mf2\urlsMatch($u, $url);
-				})) > 0) {
-				$representativeHCards[] = $hCard;
-				unset($hCards[$index]);
-			}
-		}
-
-		// print_r($representativeHCards);
-		// exit;
-
-		# check for `url` property that matches a `rel=me` URL
-		if ($relMeUrls) {
-			foreach ($hCards as $index => $hCard) {
-				#print_r($hCard); exit;
-
-				if (Mf2\hasProp($hCard, 'url')) {
-					print_r(MF2\getPlaintextArray($hCard, 'url')); exit;
-				}
-
-				print_r($hCard['properties']['url']); exit;
-
-
-				$foo = array_filter($hCard['properties']['url'], function ($u) use ($relMeUrls) {
-					print_r($u); exit;
-
-				});
-
-
-
-				if (Mf2\hasProp($hCard, 'url') && count(array_filter($hCard['properties']['url'], function ($u) use ($relMeUrls) {
-					return in_array(Indieweb\normaliseUrl($u), $relMeUrls);
-				})) > 0) {
-					$representativeHCards[] = $hCard;
-					unset($hCards[$index]);
-				}
-			}
-		}
-
-		print_r($representativeHCards);
-		exit;
-
-		print_r($representativeHCards);
-		print_r($hCards);
-		#var_dump($err);
-		exit;
-
-		# check if the page has *one single h-card* and the `url` matches the page URL
-		if (count($hCards) == 1) {
-			$hCard = reset($hCards);
-			if (Mf2\hasProp($hCard, 'url') && count(array_filter($hCard['properties']['url'], function ($u) use ($url) {
-				return Mf2\urlsMatch($u, $url);
-			})) > 0) {
-				$representativeHCards[] = $hCard;
-			}
-		}
-
-		$firstHCard = null;
-
-		if (count($allhCards) > 0) {
-			$firstHCard = $allhCards[0];
-		}
-
-		return crossOriginResponse(render('validate-h-card.html', array(
-			'showResult' => true,
-			'firstHCard' => $firstHCard,
-			'representativeHCards' => $representativeHCards,
-			'url' => htmlspecialchars($url)
-		)));
 	}
 });
 

--- a/web/index.php
+++ b/web/index.php
@@ -2,9 +2,6 @@
 
 namespace Indieweb\IndiewebifyMe;
 
-error_reporting(E_ALL);
-ini_set('display_errors', '1');
-
 ob_start();
 require __DIR__ . '/../vendor/autoload.php';
 ob_end_clean();


### PR DESCRIPTION
This resolves #99 and streamlines a few things on the /validate-h-card page:

- Updated https://github.com/barnabywalters/php-mf-cleaner 
- Use the mf-cleaner's updated `getRepresentativeHCard` method instead of duplicating the rep h-card code inline
- Flatten some of the if/else logic in the page, splitting out `if ($error)...` and `if ($showResult)...`
- Use the mf-cleaner's `getPlaintextArray` to parse multi-value mf2 properties for display
- Updated microformats.org links to https
- Added HTML `<label>` for accessibility, added `required` attribute
- Some updates to reduce the amount of PHP notices (when error_reporting is on), using `isset` and null coalescing operator

You can test these updates on https://iwm.gregoreatworld.com/validate-h-card/ 

The URL from #99 is working with these updates:
https://iwm.gregoreatworld.com/validate-h-card/?url=https%3A%2F%2Fpresence-gqle9t8ex-johanbove.vercel.app%2F

**Edit:** contextualized the message when there's no rep h-card, but one or more h-cards:
- multiple h-cards: "Multiple h-cards were found on your site! Consider only having one and marking it up..." [Example](https://iwm.gregoreatworld.com/validate-h-card/?url=https%3A%2F%2Findieweb.org%2FUser%3AGregorlove.com)
- one h-card: "An h-card was found on your site! Consider marking it up..." [Example](https://iwm.gregoreatworld.com/validate-h-card/?url=https%3A%2F%2Findieweb.org%2FUser%3ATantek.com)


